### PR TITLE
Fix InvalidOperationException when changing the url of the video whil…

### DIFF
--- a/Youtube downloader/MainForm.cs
+++ b/Youtube downloader/MainForm.cs
@@ -558,6 +558,7 @@ namespace Youtube_downloader
         private void txtURL_TextChanged(object sender, EventArgs e)
         {
             var urlData = new URLData() { URL = txtURL.Text, title = txtfilename.Text }; //this object is used to send info to the backgroundworker thread
+            YTtitlebackgroundWorker.WorkerSupportsCancellation = true;
             if (!YTtitlebackgroundWorker.IsBusy)
             {
                 YTtitlebackgroundWorker.RunWorkerAsync(urlData);


### PR DESCRIPTION
…e the program is retrieving the title.

Exception message:
This BackgroundWorker states that it doesn't support cancellation.
Modify WorkerSupportsCancellation to state that it does support cancellation.

How it happened:
- I have a youtube link currently in my clipboard. I tried changing the url while the program is retrieving the title. And suddenly an InvalidOperationException was triggered.
