### PR TITLE
Remove CancelAsync() action when the background worker is busy, to prevent an InvalidOperationException exception when the user changes the url

### DIFF
--- a/Youtube downloader/MainForm.cs
+++ b/Youtube downloader/MainForm.cs
@@ -563,11 +563,12 @@ namespace Youtube_downloader
             {
                 YTtitlebackgroundWorker.RunWorkerAsync(urlData);
             }
-            else
-            {
-                YTtitlebackgroundWorker.CancelAsync();
-                YTtitlebackgroundWorker.RunWorkerAsync(urlData);
-            }
+            //else
+            //{
+            //    //If it's busy, then let the background worker continue running
+            //    YTtitlebackgroundWorker.CancelAsync();
+            //    YTtitlebackgroundWorker.RunWorkerAsync(urlData);
+            //}
         }
 
         private string GetTitle(string URL)//string site


### PR DESCRIPTION
The background worker can still retrieve the title when the user inputs a new URL.
There seems to be no issue even if the user changes the URL during the background operation, the title of the new URL is still retrieved despite the URL changed during the background operation.
